### PR TITLE
PAN-417 Fix for TPC-H 11 query

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
@@ -121,6 +121,8 @@ public class RelToSqlConverter extends SqlImplementor
   public Result visit(Join e) {
     final Result leftResult = visitChild(0, e.getLeft()).resetAlias();
     final Result rightResult = visitChild(1, e.getRight()).resetAlias();
+    final SqlNode leftNode = leftResult.asFrom();
+    final SqlNode rightNode = rightResult.asFrom();
     final Context leftContext = leftResult.qualifiedContext();
     final Context rightContext = rightResult.qualifiedContext();
     SqlNode sqlCondition = null;
@@ -137,10 +139,10 @@ public class RelToSqlConverter extends SqlImplementor
     }
     SqlNode join =
         new SqlJoin(POS,
-            leftResult.asFrom(),
+            leftNode,
             SqlLiteral.createBoolean(false, POS),
             joinType.symbol(POS),
-            rightResult.asFrom(),
+            rightNode,
             condType,
             sqlCondition);
     return result(join, leftResult, rightResult);

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -1169,9 +1169,27 @@ public abstract class SqlImplementor {
         if (node.getKind() == SqlKind.AS) {
           n = ((SqlCall) node).operand(0);
         }
+        addColumnAliases(n);
         return SqlStdOperatorTable.AS.createCall(POS, n, new SqlIdentifier(neededAlias, POS));
       }
       return node;
+    }
+
+    /** Adds aliases to columns named implicitly as EXPR$0, EXPR$1, ... */
+    private void addColumnAliases(SqlNode node) {
+      if (node instanceof SqlSelect && neededType != null) {
+        SqlNodeList selectList = ((SqlSelect) node).getSelectList();
+        for (int i = 0; i < selectList.size(); i++) {
+          String name = neededType.getFieldNames().get(i);
+          if (name.startsWith("EXPR$")) {
+            SqlNode e = selectList.get(i);
+            SqlNode aliased = SqlStdOperatorTable.AS.createCall(
+                POS, e, new SqlIdentifier(name, POS));
+            selectList.set(i, aliased);
+            ordinalMap.remove(name.toLowerCase(Locale.ROOT));
+          }
+        }
+      }
     }
 
     public SqlSelect subSelect() {


### PR DESCRIPTION
The problem is that there is special aliases in form of `EXPR$...` which are not provided as aliases in generated SQL query but are hold in `SqlImplementor.ordinalMap` for further inlining (the logic is in `AliasContext.field()`). It's OK inside one select query, but when we have subquery it's generally not possible to inline expression from subquery into outer query. That why we need to "materialize" these aliases, make them explicit.