### PR TITLE
PAN-565 Sort and limit don't get pushed down to JDBC

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcRules.java
+++ b/core/src/main/java/org/apache/calcite/adapter/jdbc/JdbcRules.java
@@ -766,7 +766,7 @@ public class JdbcRules {
 
       final RelNode input;
       if (convertInputTraits) {
-        input = convert(sort.getInput(), traitSet);
+        input = convert(sort.getInput(), out);
       } else {
         input = sort.getInput();
       }


### PR DESCRIPTION
Fixed `JdbcSortRule` to convert input to JDBC convention only, not collation (which is not implementable).