### PR TITLE
Convert boolean literals to expressions in join condition.

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlUtil.java
@@ -391,7 +391,7 @@ public abstract class SqlUtil {
   /**
    * If a join uses ON with a boolean literal convert it to an expression.
    *
-   * <p>Convert "a JOIN b ON TRUE" with "a JOIN b ON 1 = 1".
+   * <p>Convert "a JOIN b ON TRUE" to "a JOIN b ON 1 = 1".
    *
    * @param join
    * @param pos

--- a/core/src/main/java/org/apache/calcite/sql/SqlUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlUtil.java
@@ -389,6 +389,27 @@ public abstract class SqlUtil {
   }
 
   /**
+   * If a join uses ON with a boolean literal convert it to an expression.
+   *
+   * <p>Convert "a JOIN b ON TRUE" with "a JOIN b ON 1 = 1".
+   *
+   * @param join
+   * @param pos
+   */
+  public static void convertJoinOnToExpression(SqlJoin join, SqlParserPos pos) {
+    if (join.getConditionType() == JoinConditionType.ON
+        && join.getCondition().getKind() == SqlKind.LITERAL) {
+      String compareTo = (((SqlLiteral) join.getCondition()).getValue().equals(true))
+          ? "1" : "0";
+      SqlNode op = new SqlBasicCall(SqlStdOperatorTable.EQUALS, new SqlNode[]{
+          SqlLiteral.createExactNumeric("1", pos),
+          SqlLiteral.createExactNumeric(compareTo, pos)
+      }, pos);
+      join.setOperand(5, op);
+    }
+  }
+
+  /**
    * Concatenates string literals.
    *
    * <p>This method takes an array of arguments, since pairwise concatenation

--- a/core/src/main/java/org/apache/calcite/sql/SqlUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlUtil.java
@@ -391,10 +391,11 @@ public abstract class SqlUtil {
   /**
    * If a join uses ON with a boolean literal convert it to an expression.
    *
-   * <p>Convert "a JOIN b ON TRUE" to "a JOIN b ON 1 = 1".
+   * <p>Convert "a JOIN b ON TRUE" to "a JOIN b ON 1 = 1". This should be replaced
+   * with something that checks the new dialect method supportsDataType(bool).
    *
-   * @param join
-   * @param pos
+   * @param join the join to convert
+   * @param pos parser position
    */
   public static void convertJoinOnToExpression(SqlJoin join, SqlParserPos pos) {
     if (join.getConditionType() == JoinConditionType.ON

--- a/core/src/main/java/org/apache/calcite/sql/dialect/MssqlSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/MssqlSqlDialect.java
@@ -18,9 +18,7 @@ package org.apache.calcite.sql.dialect;
 
 import org.apache.calcite.avatica.util.TimeUnitRange;
 import org.apache.calcite.rel.type.RelDataTypeSystem;
-import org.apache.calcite.sql.JoinConditionType;
 import org.apache.calcite.sql.SqlAbstractDateTimeLiteral;
-import org.apache.calcite.sql.SqlBasicCall;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlDialect;
 import org.apache.calcite.sql.SqlFunction;
@@ -34,7 +32,6 @@ import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlUtil;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
-import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.ReturnTypes;
 
 /**

--- a/core/src/main/java/org/apache/calcite/sql/dialect/MssqlSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/MssqlSqlDialect.java
@@ -83,17 +83,7 @@ public class MssqlSqlDialect extends SqlDialect {
       case JOIN:
         // MS SQL does not support boolean literals. "ON TRUE" is converted to "ON 1 = 1".
         SqlJoin join = (SqlJoin) call;
-        if (join.getConditionType() == JoinConditionType.ON
-            && join.getCondition().getKind() == SqlKind.LITERAL) {
-          SqlParserPos pos = call.getParserPosition();
-          String compareTo = (((SqlLiteral) join.getCondition()).getValue().equals(true))
-              ? "1" : "0";
-          SqlNode op = new SqlBasicCall(SqlStdOperatorTable.EQUALS, new SqlNode[]{
-              SqlLiteral.createExactNumeric("1", pos),
-              SqlLiteral.createExactNumeric(compareTo, pos)
-          }, pos);
-          join.setOperand(5, op);
-        }
+        SqlUtil.convertJoinOnToExpression(join, call.getParserPosition());
         super.unparseCall(writer, call, leftPrec, rightPrec);
         break;
 

--- a/core/src/main/java/org/apache/calcite/sql/dialect/MssqlSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/MssqlSqlDialect.java
@@ -18,19 +18,23 @@ package org.apache.calcite.sql.dialect;
 
 import org.apache.calcite.avatica.util.TimeUnitRange;
 import org.apache.calcite.rel.type.RelDataTypeSystem;
+import org.apache.calcite.sql.JoinConditionType;
 import org.apache.calcite.sql.SqlAbstractDateTimeLiteral;
+import org.apache.calcite.sql.SqlBasicCall;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlDialect;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlIntervalLiteral;
 import org.apache.calcite.sql.SqlIntervalQualifier;
+import org.apache.calcite.sql.SqlJoin;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlUtil;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.ReturnTypes;
 
 /**
@@ -74,6 +78,23 @@ public class MssqlSqlDialect extends SqlDialect {
           return;
         }
         unparseFloor(writer, call);
+        break;
+
+      case JOIN:
+        // MS SQL does not support boolean literals. "ON TRUE" is converted to "ON 1 = 1".
+        SqlJoin join = (SqlJoin) call;
+        if (join.getConditionType() == JoinConditionType.ON
+            && join.getCondition().getKind() == SqlKind.LITERAL) {
+          SqlParserPos pos = call.getParserPosition();
+          String compareTo = (((SqlLiteral) join.getCondition()).getValue().equals(true))
+              ? "1" : "0";
+          SqlNode op = new SqlBasicCall(SqlStdOperatorTable.EQUALS, new SqlNode[]{
+              SqlLiteral.createExactNumeric("1", pos),
+              SqlLiteral.createExactNumeric(compareTo, pos)
+          }, pos);
+          join.setOperand(5, op);
+        }
+        super.unparseCall(writer, call, leftPrec, rightPrec);
         break;
 
       default:

--- a/core/src/main/java/org/apache/calcite/sql/dialect/OracleSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/OracleSqlDialect.java
@@ -85,17 +85,7 @@ public class OracleSqlDialect extends SqlDialect {
       case JOIN:
         // Oracle does not support boolean literals. "ON TRUE" is converted to "ON 1 = 1".
         SqlJoin join = (SqlJoin) call;
-        if (join.getConditionType() == JoinConditionType.ON
-            && join.getCondition().getKind() == SqlKind.LITERAL) {
-          SqlParserPos pos = call.getParserPosition();
-          String compareTo = (((SqlLiteral) join.getCondition()).getValue().equals(true))
-              ? "1" : "0";
-          SqlNode op = new SqlBasicCall(SqlStdOperatorTable.EQUALS, new SqlNode[]{
-              SqlLiteral.createExactNumeric("1", pos),
-              SqlLiteral.createExactNumeric(compareTo, pos)
-          }, pos);
-          join.setOperand(5, op);
-        }
+        SqlUtil.convertJoinOnToExpression(join, call.getParserPosition());
         super.unparseCall(writer, call, leftPrec, rightPrec);
         break;
 

--- a/core/src/main/java/org/apache/calcite/sql/dialect/OracleSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/OracleSqlDialect.java
@@ -17,20 +17,15 @@
 package org.apache.calcite.sql.dialect;
 
 import org.apache.calcite.avatica.util.TimeUnitRange;
-import org.apache.calcite.sql.JoinConditionType;
-import org.apache.calcite.sql.SqlBasicCall;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlDialect;
 import org.apache.calcite.sql.SqlJoin;
-import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlLiteral;
-import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlUtil;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.fun.SqlFloorFunction;
 import org.apache.calcite.sql.fun.SqlLibraryOperators;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
-import org.apache.calcite.sql.parser.SqlParserPos;
 
 /**
  * A <code>SqlDialect</code> implementation for the Oracle database.

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -1298,7 +1298,7 @@ public class RelToSqlConverterTest {
 
   @Test public void testFullJoinOnTrueCondition() {
     String query = "select * from \"department\"\n"
-        + "FULL JOIN \"employee\" ON true";
+        + "FULL JOIN \"employee\" ON TRUE";
     String expected = "SELECT *\n"
         + "FROM \"foodmart\".\"department\"\n"
         + "FULL JOIN \"foodmart\".\"employee\" ON TRUE";

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -1298,11 +1298,42 @@ public class RelToSqlConverterTest {
 
   @Test public void testFullJoinOnTrueCondition() {
     String query = "select * from \"department\"\n"
-        + "FULL JOIN \"employee\" ON TRUE";
+        + "FULL JOIN \"employee\" ON true";
     String expected = "SELECT *\n"
         + "FROM \"foodmart\".\"department\"\n"
         + "FULL JOIN \"foodmart\".\"employee\" ON TRUE";
-    sql(query).ok(expected);
+    String mssql = "SELECT *\n"
+        + "FROM [foodmart].[department]\n"
+        + "FULL JOIN [foodmart].[employee] ON 1 = 1";
+    String oracle = "SELECT *\n"
+        + "FROM \"foodmart\".\"department\"\n"
+        + "FULL JOIN \"foodmart\".\"employee\" ON 1 = 1";
+    sql(query)
+        .ok(expected)
+        .withMssql()
+        .ok(mssql)
+        .withOracle()
+        .ok(oracle);
+  }
+
+  @Test public void testFullJoinOnFalseCondition() {
+    String query = "select * from \"department\"\n"
+        + "FULL JOIN \"employee\" ON false";
+    String expected = "SELECT *\n"
+        + "FROM \"foodmart\".\"department\"\n"
+        + "FULL JOIN \"foodmart\".\"employee\" ON FALSE";
+    String mssql = "SELECT *\n"
+        + "FROM [foodmart].[department]\n"
+        + "FULL JOIN [foodmart].[employee] ON 1 = 0";
+    String oracle = "SELECT *\n"
+        + "FROM \"foodmart\".\"department\"\n"
+        + "FULL JOIN \"foodmart\".\"employee\" ON 1 = 0";
+    sql(query)
+        .ok(expected)
+        .withMssql()
+        .ok(mssql)
+        .withOracle()
+        .ok(oracle);
   }
 
   @Test public void testSimpleIn() {


### PR DESCRIPTION
Oracle & mssql do not support boolean literals.
Convert `true` -> `1=1` and `false` -> `1=0`.
It's not easily possible to change all instances of a boolean in a query, since `SqlLiteral.unparse` doesn't have a dialect in context, but there is only one that really matters - the `on` clause of a join. `where true` for example will automatically be removed much earlier.