### PR TITLE
[Discussion] Limit Hashset collection size [don't merge]

### DIFF
--- a/babel/pom.xml
+++ b/babel/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.21.0-c6-SNAPSHOT</version>
+    <version>1.21.0-mh-SNAPSHOT</version>
   </parent>
 
   <artifactId>calcite-babel</artifactId>
   <packaging>jar</packaging>
-  <version>1.21.0-c6-SNAPSHOT</version>
+  <version>1.21.0-mh-SNAPSHOT</version>
   <name>Calcite Babel</name>
   <description>Calcite Babel</description>
 

--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.21.0-c6-SNAPSHOT</version>
+    <version>1.21.0-mh-SNAPSHOT</version>
   </parent>
 
   <artifactId>calcite-cassandra</artifactId>
   <packaging>jar</packaging>
-  <version>1.21.0-c6-SNAPSHOT</version>
+  <version>1.21.0-mh-SNAPSHOT</version>
   <name>Calcite Cassandra</name>
   <description>Cassandra adapter for Calcite</description>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.21.0-c6-SNAPSHOT</version>
+    <version>1.21.0-mh-SNAPSHOT</version>
   </parent>
 
   <artifactId>calcite-core</artifactId>
   <packaging>jar</packaging>
-  <version>1.21.0-c6-SNAPSHOT</version>
+  <version>1.21.0-mh-SNAPSHOT</version>
   <name>Calcite Core</name>
   <description>Core Calcite APIs and engine.</description>
 

--- a/druid/pom.xml
+++ b/druid/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.21.0-c6-SNAPSHOT</version>
+    <version>1.21.0-mh-SNAPSHOT</version>
   </parent>
 
   <artifactId>calcite-druid</artifactId>
   <packaging>jar</packaging>
-  <version>1.21.0-c6-SNAPSHOT</version>
+  <version>1.21.0-mh-SNAPSHOT</version>
   <name>Calcite Druid</name>
   <description>Druid adapter for Calcite</description>
 

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -21,12 +21,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.21.0-c6-SNAPSHOT</version>
+    <version>1.21.0-mh-SNAPSHOT</version>
   </parent>
 
   <artifactId>calcite-elasticsearch</artifactId>
   <packaging>jar</packaging>
-  <version>1.21.0-c6-SNAPSHOT</version>
+  <version>1.21.0-mh-SNAPSHOT</version>
   <name>Calcite Elasticsearch</name>
   <description>Elasticsearch adapter for Calcite</description>
 

--- a/example/csv/pom.xml
+++ b/example/csv/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite-example</artifactId>
-    <version>1.21.0-c6-SNAPSHOT</version>
+    <version>1.21.0-mh-SNAPSHOT</version>
   </parent>
 
   <artifactId>calcite-example-csv</artifactId>
   <packaging>jar</packaging>
-  <version>1.21.0-c6-SNAPSHOT</version>
+  <version>1.21.0-mh-SNAPSHOT</version>
   <name>Calcite Example CSV</name>
   <description>An example Calcite provider that reads CSV files</description>
 

--- a/example/function/pom.xml
+++ b/example/function/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite-example</artifactId>
-    <version>1.21.0-c6-SNAPSHOT</version>
+    <version>1.21.0-mh-SNAPSHOT</version>
   </parent>
 
   <artifactId>calcite-example-function</artifactId>
   <packaging>jar</packaging>
-  <version>1.21.0-c6-SNAPSHOT</version>
+  <version>1.21.0-mh-SNAPSHOT</version>
   <name>Calcite Example Function</name>
   <description>Examples of user-defined Calcite functions</description>
 

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -20,13 +20,13 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.21.0-c6-SNAPSHOT</version>
+    <version>1.21.0-mh-SNAPSHOT</version>
   </parent>
 
   <!-- The basics. -->
   <artifactId>calcite-example</artifactId>
   <packaging>pom</packaging>
-  <version>1.21.0-c6-SNAPSHOT</version>
+  <version>1.21.0-mh-SNAPSHOT</version>
   <name>Calcite Examples</name>
   <description>Calcite examples</description>
 

--- a/file/pom.xml
+++ b/file/pom.xml
@@ -19,13 +19,13 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.21.0-c6-SNAPSHOT</version>
+    <version>1.21.0-mh-SNAPSHOT</version>
   </parent>
 
   <!-- The basics. -->
   <artifactId>calcite-file</artifactId>
   <packaging>jar</packaging>
-  <version>1.21.0-c6-SNAPSHOT</version>
+  <version>1.21.0-mh-SNAPSHOT</version>
   <name>Calcite File</name>
   <description>Calcite provider that reads files and URIs</description>
 

--- a/geode/pom.xml
+++ b/geode/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.21.0-c6-SNAPSHOT</version>
+    <version>1.21.0-mh-SNAPSHOT</version>
   </parent>
 
   <artifactId>calcite-geode</artifactId>
   <packaging>jar</packaging>
-  <version>1.21.0-c6-SNAPSHOT</version>
+  <version>1.21.0-mh-SNAPSHOT</version>
   <name>Calcite Geode</name>
   <description>Geode adapter for Calcite</description>
 

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.21.0-c6-SNAPSHOT</version>
+    <version>1.21.0-mh-SNAPSHOT</version>
   </parent>
 
   <!-- The basics. -->

--- a/linq4j/pom.xml
+++ b/linq4j/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.21.0-c6-SNAPSHOT</version>
+    <version>1.21.0-mh-SNAPSHOT</version>
   </parent>
 
   <artifactId>calcite-linq4j</artifactId>
   <packaging>jar</packaging>
-  <version>1.21.0-c6-SNAPSHOT</version>
+  <version>1.21.0-mh-SNAPSHOT</version>
   <name>Calcite Linq4j</name>
   <description>Calcite APIs for LINQ (Language-Integrated Query) in Java</description>
 

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/EnumerableDefaults.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/EnumerableDefaults.java
@@ -49,7 +49,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -441,7 +440,7 @@ public abstract class EnumerableDefaults {
   public static <TSource> Enumerable<TSource> distinct(
       Enumerable<TSource> enumerable) {
     final Enumerator<TSource> os = enumerable.enumerator();
-    final Set<TSource> set = new HashSet<>();
+    final Set<TSource> set = new LimitedHashSet<>();
     while (os.moveNext()) {
       set.add(os.current());
     }
@@ -458,7 +457,7 @@ public abstract class EnumerableDefaults {
     if (comparer == Functions.identityComparer()) {
       return distinct(enumerable);
     }
-    final Set<Wrapped<TSource>> set = new HashSet<>();
+    final Set<Wrapped<TSource>> set = new LimitedHashSet<>();
     Function1<TSource, Wrapped<TSource>> wrapper = wrapperFor(comparer);
     Function1<Wrapped<TSource>, TSource> unwrapper = unwrapper();
     enumerable.select(wrapper).into(set);
@@ -533,7 +532,7 @@ public abstract class EnumerableDefaults {
    */
   public static <TSource> Enumerable<TSource> except(
       Enumerable<TSource> source0, Enumerable<TSource> source1) {
-    Set<TSource> set = new HashSet<>();
+    Set<TSource> set = new LimitedHashSet<>();
     source0.into(set);
     try (Enumerator<TSource> os = source1.enumerator()) {
       while (os.moveNext()) {
@@ -555,7 +554,7 @@ public abstract class EnumerableDefaults {
     if (comparer == Functions.identityComparer()) {
       return except(source0, source1);
     }
-    Set<Wrapped<TSource>> set = new HashSet<>();
+    Set<Wrapped<TSource>> set = new LimitedHashSet<>();
     Function1<TSource, Wrapped<TSource>> wrapper = wrapperFor(comparer);
     source0.select(wrapper).into(set);
     try (Enumerator<Wrapped<TSource>> os =
@@ -950,9 +949,9 @@ public abstract class EnumerableDefaults {
    */
   public static <TSource> Enumerable<TSource> intersect(
       Enumerable<TSource> source0, Enumerable<TSource> source1) {
-    Set<TSource> set0 = new HashSet<>();
+    Set<TSource> set0 = new LimitedHashSet<>();
     source0.into(set0);
-    Set<TSource> set1 = new HashSet<>();
+    Set<TSource> set1 = new LimitedHashSet<>();
     try (Enumerator<TSource> os = source1.enumerator()) {
       while (os.moveNext()) {
         TSource o = os.current();
@@ -975,10 +974,10 @@ public abstract class EnumerableDefaults {
     if (comparer == Functions.identityComparer()) {
       return intersect(source0, source1);
     }
-    Set<Wrapped<TSource>> set0 = new HashSet<>();
+    Set<Wrapped<TSource>> set0 = new LimitedHashSet<>();
     Function1<TSource, Wrapped<TSource>> wrapper = wrapperFor(comparer);
     source0.select(wrapper).into(set0);
-    Set<Wrapped<TSource>> set1 = new HashSet<>();
+    Set<Wrapped<TSource>> set1 = new LimitedHashSet<>();
     try (Enumerator<Wrapped<TSource>> os = source1.select(wrapper).enumerator()) {
       while (os.moveNext()) {
         Wrapped<TSource> o = os.current();
@@ -1078,7 +1077,7 @@ public abstract class EnumerableDefaults {
           Enumerator<TInner> inners = Linq4j.emptyEnumerator();
           Set<TKey> unmatchedKeys =
               generateNullsOnLeft
-                  ? new HashSet<>(innerLookup.keySet())
+                  ? new LimitedHashSet<>(innerLookup.keySet())
                   : null;
 
           public TResult current() {
@@ -2746,7 +2745,7 @@ public abstract class EnumerableDefaults {
    */
   public static <TSource> Enumerable<TSource> union(Enumerable<TSource> source0,
       Enumerable<TSource> source1) {
-    Set<TSource> set = new HashSet<>();
+    Set<TSource> set = new LimitedHashSet<>();
     source0.into(set);
     source1.into(set);
     return Linq4j.asEnumerable(set);
@@ -2761,7 +2760,7 @@ public abstract class EnumerableDefaults {
     if (comparer == Functions.identityComparer()) {
       return union(source0, source1);
     }
-    Set<Wrapped<TSource>> set = new HashSet<>();
+    Set<Wrapped<TSource>> set = new LimitedHashSet<>();
     Function1<TSource, Wrapped<TSource>> wrapper = wrapperFor(comparer);
     Function1<Wrapped<TSource>, TSource> unwrapper = unwrapper();
     source0.select(wrapper).into(set);

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/LimitedCollectionsException.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/LimitedCollectionsException.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.linq4j;
+
+/**
+ *
+ */
+public class LimitedCollectionsException extends RuntimeException {
+
+  /**
+   * something
+   */
+  public LimitedCollectionsException() {
+    super();
+  }
+
+  /**
+   * @param s something
+   */
+  public LimitedCollectionsException(String s) {
+    super(s);
+  }
+}
+// End LimitedCollectionsException.java

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/LimitedHashSet.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/LimitedHashSet.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.linq4j;
+
+import java.util.Collection;
+import java.util.HashSet;
+
+/**
+ * @param <E> something
+ */
+public class LimitedHashSet<E> extends HashSet<E> {
+
+  private static float load = 0.9f;
+  private static int limit = Math.round((1 << 21) / load) + 1;   //21 = 2.3 Mill
+  private static int initCapacity = 1 << 10;
+
+  /**
+   * something
+   */
+  public LimitedHashSet() {
+    super(initCapacity, load);
+  }
+
+  public LimitedHashSet(Collection<? extends E> c) {
+    super(Math.max((int) (c.size() / load) + 1, initCapacity), load);
+    super.addAll(c);
+  }
+
+  /**
+   * @param e something
+   * @return boolean
+   */
+  @Override public boolean add(E e) {
+    boolean ret = super.add(e);
+    if (ret && super.size() > limit) {
+      throw new LimitedCollectionsException("Exceeding query row size limit: (" + limit + ").");
+    }
+    return ret;
+  }
+}
+// End LimitedHashSet.java

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/LimitedHashSet.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/LimitedHashSet.java
@@ -25,7 +25,7 @@ import java.util.HashSet;
 public class LimitedHashSet<E> extends HashSet<E> {
 
   private static float load = 0.9f;
-  private static int limit = Math.round((1 << 21) / load) + 1;   //21 = 2.3 Mill
+  private static int limit = Math.round((1 << 21) * load) - 1;   //21 = 2 Mill * .9 = 1.88 Mill
   private static int initCapacity = 1 << 10;
 
   /**

--- a/mongodb/pom.xml
+++ b/mongodb/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.21.0-c6-SNAPSHOT</version>
+    <version>1.21.0-mh-SNAPSHOT</version>
   </parent>
 
   <artifactId>calcite-mongodb</artifactId>
   <packaging>jar</packaging>
-  <version>1.21.0-c6-SNAPSHOT</version>
+  <version>1.21.0-mh-SNAPSHOT</version>
   <name>Calcite MongoDB</name>
   <description>MongoDB adapter for Calcite</description>
 

--- a/pig/pom.xml
+++ b/pig/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.21.0-c6-SNAPSHOT</version>
+    <version>1.21.0-mh-SNAPSHOT</version>
   </parent>
 
   <artifactId>calcite-pig</artifactId>
   <packaging>jar</packaging>
-  <version>1.21.0-c6-SNAPSHOT</version>
+  <version>1.21.0-mh-SNAPSHOT</version>
   <name>Calcite Pig</name>
   <description>Pig adapter for Calcite</description>
 

--- a/piglet/pom.xml
+++ b/piglet/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.21.0-c6-SNAPSHOT</version>
+    <version>1.21.0-mh-SNAPSHOT</version>
   </parent>
 
   <artifactId>calcite-piglet</artifactId>
   <packaging>jar</packaging>
-  <version>1.21.0-c6-SNAPSHOT</version>
+  <version>1.21.0-mh-SNAPSHOT</version>
   <name>Calcite Piglet</name>
   <description>Pig-like language built on top of Calcite algebra</description>
 

--- a/plus/pom.xml
+++ b/plus/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.21.0-c6-SNAPSHOT</version>
+    <version>1.21.0-mh-SNAPSHOT</version>
   </parent>
 
   <artifactId>calcite-plus</artifactId>
   <packaging>jar</packaging>
-  <version>1.21.0-c6-SNAPSHOT</version>
+  <version>1.21.0-mh-SNAPSHOT</version>
   <name>Calcite Plus</name>
   <description>Miscellaneous extras for Calcite</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@ limitations under the License.
   <groupId>org.apache.calcite</groupId>
   <artifactId>calcite</artifactId>
   <packaging>pom</packaging>
-  <version>1.21.0-c6-SNAPSHOT</version>
+  <version>1.21.0-mh-SNAPSHOT</version>
 
   <!-- More project information. -->
   <name>Calcite</name>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.21.0-c6-SNAPSHOT</version>
+    <version>1.21.0-mh-SNAPSHOT</version>
   </parent>
 
   <artifactId>calcite-server</artifactId>
   <packaging>jar</packaging>
-  <version>1.21.0-c6-SNAPSHOT</version>
+  <version>1.21.0-mh-SNAPSHOT</version>
   <name>Calcite Server</name>
   <description>Calcite Server</description>
 

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.21.0-c6-SNAPSHOT</version>
+    <version>1.21.0-mh-SNAPSHOT</version>
   </parent>
 
   <artifactId>calcite-spark</artifactId>
   <packaging>jar</packaging>
-  <version>1.21.0-c6-SNAPSHOT</version>
+  <version>1.21.0-mh-SNAPSHOT</version>
   <name>Calcite Spark</name>
 
   <properties>

--- a/splunk/pom.xml
+++ b/splunk/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.21.0-c6-SNAPSHOT</version>
+    <version>1.21.0-mh-SNAPSHOT</version>
   </parent>
 
   <artifactId>calcite-splunk</artifactId>
   <packaging>jar</packaging>
-  <version>1.21.0-c6-SNAPSHOT</version>
+  <version>1.21.0-mh-SNAPSHOT</version>
   <name>Calcite Splunk</name>
   <description>Splunk adapter for Calcite; also a JDBC driver for Splunk</description>
 

--- a/ubenchmark/pom.xml
+++ b/ubenchmark/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.21.0-c6-SNAPSHOT</version>
+    <version>1.21.0-mh-SNAPSHOT</version>
   </parent>
 
   <properties>


### PR DESCRIPTION
PR is intended as discussion idea. Show how to add limited HashSet to calcite EnumerableDefaults to throw a RunTimeException on exceeding 1,88 Mill entries. 

>-- based on this stacktrace --<
`"application-akka.actor.default-dispatcher-12" #79 prio=5 os_prio=0 cpu=119690.01ms elapsed=885.15s tid=0x00007f6f2808a000 nid=0x82 runnable  [0x00007f6f5cee3000]
   java.lang.Thread.State: RUNNABLE
	at java.util.HashMap.put(java.base@11.0.4/HashMap.java:607)
	at java.util.HashSet.add(java.base@11.0.4/HashSet.java:220)
	at org.apache.calcite.linq4j.EnumerableDefaults.into(EnumerableDefaults.java:2912)
	at org.apache.calcite.linq4j.DefaultEnumerable.into(DefaultEnumerable.java:340)
	at org.apache.calcite.linq4j.EnumerableDefaults.distinct(EnumerableDefaults.java:464)
	at org.apache.calcite.linq4j.DefaultEnumerable.distinct(DefaultEnumerable.java:207)
	at Baz.bind(Unknown Source)
	at org.apache.calcite.jdbc.CalcitePrepare$CalciteSignature.enumerable(CalcitePrepare.java:355)
	at org.apache.calcite.jdbc.CalciteConnectionImpl.enumerable(CalciteConnectionImpl.java:314)
	at org.apache.calcite.jdbc.CalciteMetaImpl._createIterable(CalciteMetaImpl.java:506)
	at org.apache.calcite.jdbc.CalciteMetaImpl.createIterable(CalciteMetaImpl.java:497)
	at org.apache.calcite.avatica.AvaticaResultSet.execute(AvaticaResultSet.java:182)
	at org.apache.calcite.jdbc.CalciteResultSet.execute(CalciteResultSet.java:64)
`